### PR TITLE
Improvements to vncserver-start wrappers

### DIFF
--- a/APT/LXDE/vncserver-start
+++ b/APT/LXDE/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/APT/LXDE/xstartup
+++ b/APT/LXDE/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startlxde &

--- a/APT/LXQT/vncserver-start
+++ b/APT/LXQT/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/APT/LXQT/xstartup
+++ b/APT/LXQT/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startlxqt &

--- a/APT/MATE/vncserver-start
+++ b/APT/MATE/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/APT/MATE/xstartup
+++ b/APT/MATE/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 mate-session &

--- a/APT/XFCE4/vncserver-start
+++ b/APT/XFCE4/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/APT/XFCE4/xstartup
+++ b/APT/XFCE4/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startxfce4 &

--- a/Fedora/LXDE/vncserver-start
+++ b/Fedora/LXDE/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/Fedora/LXDE/xstartup
+++ b/Fedora/LXDE/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startlxde &

--- a/Fedora/LXQT/xstartup
+++ b/Fedora/LXQT/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startlxqt &

--- a/Fedora/MATE/xstartup
+++ b/Fedora/MATE/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 mate-session &

--- a/Fedora/XFCE4/xstartup
+++ b/Fedora/XFCE4/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startxfce4 &

--- a/Pacman/vncserver-start
+++ b/Pacman/vncserver-start
@@ -1,4 +1,4 @@
 export USER=root
 export HOME=/root
 
-vncserver -geometry 1024x768 -depth 24 -name remote-desktop :1
+vncserver -name remote-desktop :1

--- a/Pacman/xstartup
+++ b/Pacman/xstartup
@@ -1,4 +1,3 @@
 #!/bin/bash
 xrdb $HOME/.Xresources
-vncserver -geometry 1024x768 -depth 16 -name remote-desktop :1
 startlxde &


### PR DESCRIPTION
Mainly removing the geometry lines. This will make the vncserver adapt to the native resolution of whatever client is connecting instead of always force the hardcoded 1024x786 resolution, same goes for depth. Not specifying it makes vncserver use the preferred depth for the client