### PR TITLE
Several patches to improve the overall installation scripts

### DIFF
--- a/APT/LXDE/lxde_de.sh
+++ b/APT/LXDE/lxde_de.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
+apt-mark hold udisks2
 apt-get update
 apt-get install lxde-core lxterminal tightvncserver -y
 apt-get install xfe -y

--- a/APT/LXQT/lxqt_de.sh
+++ b/APT/LXQT/lxqt_de.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
+apt-mark hold udisks2
 apt-get update
 apt-get install lxqt-core lxqt-config qterminal tightvncserver -y
 apt-get install xfe -y

--- a/APT/MATE/mate_de.sh
+++ b/APT/MATE/mate_de.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
+apt-mark hold udisks2
 apt-get update
 apt-get install mate-desktop-environment-core mate-terminal tightvncserver -y
 apt-get install xfe -y

--- a/APT/XFCE4/xfce4_de.sh
+++ b/APT/XFCE4/xfce4_de.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
+apt-mark hold udisks2
 apt-get update
 apt-get install xfce4 xfce4-terminal tightvncserver -y
 apt-get install xfe -y

--- a/Fedora/MATE/mate_de.sh
+++ b/Fedora/MATE/mate_de.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
-yum groupinstall mate-desktop -y
+yum groupinstall mate-desktop -y --allowerasing
 yum install tigervnc-server -y
 
 #Setup the necessary files

--- a/Fedora/XFCE4/xfce4_de.sh
+++ b/Fedora/XFCE4/xfce4_de.sh
@@ -6,7 +6,7 @@ yum install tigervnc-server -y
 
 #Setup the necessary files
 mkdir ~/.vnc
-https://raw.githubusercontent.com/Techriz/AndronixOrigin/master/Fedora/XFCE4/xstartup -P ~/.vnc/
+wget https://raw.githubusercontent.com/Techriz/AndronixOrigin/master/Fedora/XFCE4/xstartup -P ~/.vnc/
 wget https://raw.githubusercontent.com/Techriz/AndronixOrigin/master/Fedora/LXDE/vncserver-start -P /usr/local/bin/
 wget https://raw.githubusercontent.com/Techriz/AndronixOrigin/master/Fedora/LXDE/vncserver-stop -P /usr/local/bin/
 chmod +x ~/.vnc/xstartup

--- a/Installer/Arch/amd64/additional.sh
+++ b/Installer/Arch/amd64/additional.sh
@@ -10,14 +10,19 @@ echo ""
 echo "Changing some permissions, please be patient"
 echo ""
 echo ""
-chmod 755 -R /bin /home /mnt /run /srv /tmp /var /boot /etc /lin /opt /root /sbin /sys /usr
+chmod 755 -R /bin /home /mnt /run /srv /tmp /var /boot /etc /opt /root /sbin /sys /usr
 echo "IMPORTANT"
 echo ""
 echo ""
+echo "Removing some unused packages, reclaims about 650MB"
+yes | LC_ALL=en_US.UTF-8 pacman -Rncs linux-firmware systemd-sysvinit openresolv mdadm lvm2 reiserfsprogs usbutils
 echo "If you are using Android 9 and above, you will encounter this error:"
 echo ""
 echo "could not change the root directory (Function not implemented)"
 echo ""
 echo "Simply ignore it as it does not do anything harmful"
+echo ""
+echo "updating Arch packages"
+yes | LC_ALL=en_US.UTF-8 pacman -Suuyy 
 echo ""
 echo ""

--- a/Installer/Arch/armhf/additional.sh
+++ b/Installer/Arch/armhf/additional.sh
@@ -10,7 +10,7 @@ echo ""
 echo "Changing some permissions, please be patient"
 echo ""
 echo ""
-chmod 755 -R /bin /home /mnt /run /srv /tmp /var /boot /etc /lin /opt /root /sbin /sys /usr
+chmod 755 -R /bin /home /mnt /run /srv /tmp /var /boot /etc /opt /root /sbin /sys /usr
 echo "IMPORTANT"
 echo ""
 echo ""

--- a/Installer/Arch/armhf/additional.sh
+++ b/Installer/Arch/armhf/additional.sh
@@ -14,6 +14,8 @@ chmod 755 -R /bin /home /mnt /run /srv /tmp /var /boot /etc /lin /opt /root /sbi
 echo "IMPORTANT"
 echo ""
 echo ""
+echo "Removing some unused packages, reclaims about 650MB"
+yes | LC_ALL=en_US.UTF-8 pacman -Rncs linux-firmware systemd-sysvinit openresolv mdadm lvm2 reiserfsprogs usbutils
 echo "If you are using Android 9 and above, you will encounter this error:"
 echo ""
 echo "could not change the root directory (Function not implemented)"

--- a/Installer/Arch/armhf/additional.sh
+++ b/Installer/Arch/armhf/additional.sh
@@ -22,4 +22,7 @@ echo "could not change the root directory (Function not implemented)"
 echo ""
 echo "Simply ignore it as it does not do anything harmful"
 echo ""
+echo "updating Arch packages"
+yes | LC_ALL=en_US.UTF-8 pacman -Suuyy 
+echo ""
 echo ""


### PR DESCRIPTION
For all apt based distro's: Mark udisks2 as hold, so it is not upgraded unless strictly necessary, since upgrading this fails and leaves apt in a semi-broken state. 
Fedora: Fix MATE and XFCE deployment scripts, both were not working due 2 small issues.
Arch: improve the overall installation, remove some unused packages. update the image directly after removing the obsolete packages