### PR TITLE
Enable dbus-launch for LXQT

### DIFF
--- a/Pacman/Manjaro/LXQT/xstartup
+++ b/Pacman/Manjaro/LXQT/xstartup
@@ -2,4 +2,4 @@
 unset SESSION_MANAGER
 export PULSE_SERVER=127.0.0.1
 xrdb $HOME/.Xresources
-startlxqt &
+dbus-launch startlxqt &


### PR DESCRIPTION
Now LXQT loads it's wallpaper also instead of the pitch black background
